### PR TITLE
Filter XML for invalid characters in more places

### DIFF
--- a/src/Core/Http/Serialization/XmlObjectSerializer.php
+++ b/src/Core/Http/Serialization/XmlObjectSerializer.php
@@ -115,7 +115,7 @@ class XmlObjectSerializer extends IEntitySerializer
         $resultObject = null;
         $resultObjects = null;
 
-        $responseXmlObj = simplexml_load_string($responseXml);
+        $responseXmlObj = self::loadXMLFromString($responseXml);
         foreach ($responseXmlObj as $oneXmlObj) {
             $oneXmlElementName = (string)$oneXmlObj->getName();
 
@@ -233,7 +233,7 @@ class XmlObjectSerializer extends IEntitySerializer
         $resultObject = null;
         $resultObjects = null;
 
-        $responseXmlObj = simplexml_load_string($this->sanitizeXML($message));
+        $responseXmlObj = self::loadXMLFromString($message);
 
         //handle count(*) case, for example Select count(*) from Invoice, and also handle the CDC case
         if(isset($responseXmlObj->attributes()['totalCount']) && !isset($responseXmlObj->attributes()['startPosition']) && !isset($responseXmlObj->attributes()['maxResults'])){
@@ -270,7 +270,7 @@ class XmlObjectSerializer extends IEntitySerializer
 	 * @param $string
 	 * @return string|string[]|null
 	 */
-	private function sanitizeXML($string)
+	public static function sanitizeXML($string)
 	{
 		if (!empty($string)) {
 			// remove EOT+NOREP+EOX|EOT+<char> sequence (FatturaPA)
@@ -310,5 +310,15 @@ class XmlObjectSerializer extends IEntitySerializer
 		}
 
 		return $string;
+	}
+
+	/**
+	 * Sanitizes invalid characters from string, then creates an XML object from it
+	 *
+	 * @param $xmlString
+	 * @return \SimpleXMLElement
+	 */
+	public static function loadXMLFromString($xmlString) {
+		return simplexml_load_string(self::sanitizeXML($xmlString));
 	}
 }

--- a/src/Core/HttpClients/FaultHandler.php
+++ b/src/Core/HttpClients/FaultHandler.php
@@ -1,6 +1,7 @@
 <?php
 namespace QuickBooksOnline\API\Core\HttpClients;
 
+use QuickBooksOnline\API\Core\Http\Serialization\XmlObjectSerializer;
 use QuickBooksOnline\API\Core\ServiceContext;
 
 /**
@@ -112,7 +113,7 @@ class FaultHandler
      * @var String The http response body in XML format
      */
     public function parseResponse($message){
-      $xmlObj = simplexml_load_string($message);
+      $xmlObj = XmlObjectSerializer::loadXMLFromString($message);
 
       if(!$this->isTheErrorBodyInStandardFormat($xmlObj)){
           return;

--- a/src/DataService/Batch.php
+++ b/src/DataService/Batch.php
@@ -366,7 +366,7 @@ class Batch
       try {
           // No JSON support here yet
           // de serialize object
-          $responseXmlObj = simplexml_load_string($responseBody);
+          $responseXmlObj = XmlObjectSerializer::loadXMLFromString($responseBody);
           foreach ($responseXmlObj as $oneXmlObj) {
               // process batch item
               $intuitBatchItemResponse = $this->ProcessBatchItemResponse($oneXmlObj);

--- a/src/DataService/DataService.php
+++ b/src/DataService/DataService.php
@@ -18,6 +18,7 @@ namespace QuickBooksOnline\API\DataService;
 
 use QuickBooksOnline\API\Core\CoreHelper;
 use QuickBooksOnline\API\Core\Http\Serialization\IEntitySerializer;
+use QuickBooksOnline\API\Core\Http\Serialization\XmlObjectSerializer;
 use QuickBooksOnline\API\Core\HttpClients\FaultHandler;
 use QuickBooksOnline\API\Core\HttpClients\RestHandler;
 use QuickBooksOnline\API\Core\ServiceContext;
@@ -1019,7 +1020,7 @@ class DataService
             $this->lastError = false;
             $parsedResponseBody = null;
             try {
-                $responseXmlObj = simplexml_load_string($responseBody);
+                $responseXmlObj = XmlObjectSerializer::loadXMLFromString($responseBody);
                 if ($responseXmlObj && $responseXmlObj->QueryResponse) {
                     $tmpXML = $responseXmlObj->QueryResponse->asXML();
                     $parsedResponseBody = $this->responseSerializer->Deserialize($tmpXML, false);
@@ -1105,7 +1106,7 @@ class DataService
             $this->lastError = false;
             $parsedResponseBody = null;
             try {
-                $responseXmlObj = simplexml_load_string($responseBody);
+                $responseXmlObj = XmlObjectSerializer::loadXMLFromString($responseBody);
                 if ($responseXmlObj && $responseXmlObj->QueryResponse) {
                     $parsedResponseBody = $this->responseSerializer->Deserialize($responseXmlObj->QueryResponse->asXML(), false);
                 }
@@ -1165,7 +1166,7 @@ class DataService
             $this->lastError = false;
             $returnValue = new IntuitCDCResponse();
             try {
-                $xmlObj = simplexml_load_string($responseBody);
+                $xmlObj = XmlObjectSerializer::loadXMLFromString($responseBody);
                 $responseArray = $xmlObj->CDCResponse->QueryResponse;
                 if(sizeof($responseArray) != sizeof($entityList)){
                     throw new ServiceException("The number of Entities requested on CDC does not match the number of Response.");

--- a/src/PlatformService/PlatformService.php
+++ b/src/PlatformService/PlatformService.php
@@ -3,6 +3,7 @@
 namespace QuickBooksOnline\API\PlatformService;
 
 use QuickBooksOnline\API\Core\CoreConstants;
+use QuickBooksOnline\API\Core\Http\Serialization\XmlObjectSerializer;
 use QuickBooksOnline\API\Core\ServiceContext;
 use QuickBooksOnline\API\Exception\SdkExceptions\InvalidParameterException;
 use QuickBooksOnline\API\Core\HttpClients\RequestParameters;
@@ -99,7 +100,7 @@ class PlatformService
         $uriFragment = implode(CoreConstants::SLASH_CHAR, array('v1', 'Connection', 'Reconnect'));
         $requestParameters = new RequestParameters(null, 'GET', null, $uriFragment);
         list($respCode, $respXml) = $this->restRequestHandler->sendRequest($requestParameters, $this->requestXmlDocument, null);
-        return simplexml_load_string($respXml);
+        return XmlObjectSerializer::loadXMLFromString($respXml);
     }
 
     /**
@@ -114,7 +115,7 @@ class PlatformService
         $uriFragment = implode(CoreConstants::SLASH_CHAR, array('v1', 'Connection', 'Disconnect'));
         $requestParameters = new RequestParameters(null, 'GET', null, $uriFragment);
         list($respCode, $respXml) = $this->restRequestHandler->sendRequest($requestParameters, $this->requestXmlDocument, null);
-        return simplexml_load_string($respXml);
+        return XmlObjectSerializer::loadXMLFromString($respXml);
     }
 
 
@@ -129,6 +130,6 @@ class PlatformService
         $uriFragment = implode(CoreConstants::SLASH_CHAR, array('v1', 'user', 'current'));
         $requestParameters = new RequestParameters(null, 'GET', null, $uriFragment);
         list($respCode, $respXml) = $this->restRequestHandler->sendRequest($requestParameters, $this->requestXmlDocument, null);
-        return simplexml_load_string($respXml);
+        return XmlObjectSerializer::loadXMLFromString($respXml);
     }
 }

--- a/src/Utility/IntuitErrorHandler.php
+++ b/src/Utility/IntuitErrorHandler.php
@@ -1,6 +1,7 @@
 <?php
 namespace QuickBooksOnline\API\Utility;
 
+use QuickBooksOnline\API\Core\Http\Serialization\XmlObjectSerializer;
 use QuickBooksOnline\API\Exception\IdsException;
 
 /**
@@ -21,7 +22,7 @@ class IntuitErrorHandler
             return;
         }
 
-        $responseXml = simplexml_load_string($response);
+        $responseXml = XmlObjectSerializer::loadXMLFromString($response);
         self::HandleErrorsXml($responseXml);
     }
 
@@ -71,7 +72,7 @@ class IntuitErrorHandler
         }
 
         try {
-            $doc = simplexml_load_string($inputString);
+            $doc = XmlObjectSerializer::loadXMLFromString($inputString);
         } catch (\Exception $e) {
             return false;
         }


### PR DESCRIPTION
https://github.com/nutshellcrm/QuickBooks-V3-PHP-SDK/pull/1 likely fixes the problem well enough due to the way `simplexml_load_string` needs to be called on nested XML entries instead of parsing the entire string at once, but to be safe this just replaces all of the calls to that function with a new function that filters out invalid characters and then parses.

Testing facilities in the library don't seem to have been maintained and I just couldn't get them working, so no test.  Manual test checks out, and the XML filtering code (previous PR) was approved in the parent repo.

## Testing
`composer require nutshellcrm/quickbooks-v3-php-sdk:dev-xml-filter-more-places` in the nutshell repo, then restart gearman and import from quickbooks, and send contacts/leads to quickbooks.

You can also replicate the issue by adding `$responseBody = substr_replace($responseBody, chr(0x02), 620, 0);` after line 1108 in `DataService.php`, which adds an invalid character, and then add
```php
$client = new Nut_Quickbooks_Client();
$item = $client->FindAll('Account');
var_export($item);
```
into an action in your foo controller.  You'll see a PCDATA error if invalid characters aren't stripped, and no error if they are.